### PR TITLE
Make board fill whole screen width

### DIFF
--- a/project/src/main/java/de/earthlingz/oerszebra/BoardView/BoardView.java
+++ b/project/src/main/java/de/earthlingz/oerszebra/BoardView/BoardView.java
@@ -396,7 +396,7 @@ public class BoardView extends View implements BoardViewModel.BoardViewModelList
         //for the android designer
         int boardSize = boardViewModel != null?boardViewModel.getBoardSize():8;
 
-        mSizeX = mSizeY = Math.min(getMeasuredWidth(), getMeasuredHeight() /2);
+        mSizeX = mSizeY = Math.min(getMeasuredWidth(), getMeasuredHeight());
         mSizeCell = Math.min(mSizeX / (boardSize + 1), mSizeY / (boardSize + 1));
         lineWidth = Math.max(1f, mSizeCell / 40f);
         gridCirclesRadius = Math.max(3f, mSizeCell / 13f);


### PR DESCRIPTION
I think it is better that the board fill as much of the screen as possible and the addtional status text shrinks to fit the remaining space. This PR make sure the board does this.

Screenshots are from the head of the `develop` branch which already includes some changes to the status area text.

Before: 

![Screenshot_20190707-211253](https://user-images.githubusercontent.com/5096681/60772854-8ed46e00-a0fc-11e9-98b3-8fa0ed2e1b17.png)

After: 

![Screenshot_1563392686](https://user-images.githubusercontent.com/5096681/61406650-92c27600-a8dc-11e9-9914-28e7894493bb.png)
