### PR TITLE
Responsive status area layout

### DIFF
--- a/project/src/main/java/de/earthlingz/oerszebra/DroidZebra.java
+++ b/project/src/main/java/de/earthlingz/oerszebra/DroidZebra.java
@@ -335,22 +335,6 @@ public class DroidZebra extends AppCompatActivity implements MoveStringConsumer,
             mBoardView.setOnMakeMoveListener(this);
             mBoardView.requestFocus();
 
-            ((ImageButton)findViewById(R.id.status_undo)).setImageDrawable(new IconDrawable(this, MaterialIcons.md_undo)
-                    .colorRes(R.color.white)
-                    .sizeDp(30));
-
-            ((ImageButton)findViewById(R.id.status_redo)).setImageDrawable(new IconDrawable(this, MaterialIcons.md_redo)
-                    .colorRes(R.color.white)
-                    .sizeDp(30));
-
-            ((ImageButton)findViewById(R.id.status_rotate)).setImageDrawable(new IconDrawable(this, MaterialIcons.md_rotate_right)
-                    .colorRes(R.color.white)
-                    .sizeDp(30));
-
-            ((ImageButton)findViewById(R.id.status_first_move)).setImageDrawable(new IconDrawable(this, MaterialIcons.md_fast_rewind)
-                    .colorRes(R.color.white)
-                    .sizeDp(30));
-
             if (Intent.ACTION_SEND.equals(action) && type != null) {
                 if ("text/plain".equals(type) || "message/rfc822".equals(type)) {
                     String input = intent.getStringExtra(Intent.EXTRA_TEXT);

--- a/project/src/main/res/drawable/ic_fast_rewind_white_24dp.xml
+++ b/project/src/main/res/drawable/ic_fast_rewind_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M11,18L11,6l-8.5,6 8.5,6zM11.5,12l8.5,6L20,6l-8.5,6z"/>
+</vector>

--- a/project/src/main/res/drawable/ic_redo_white_24dp.xml
+++ b/project/src/main/res/drawable/ic_redo_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z"/>
+</vector>

--- a/project/src/main/res/drawable/ic_rotate_right_white_24dp.xml
+++ b/project/src/main/res/drawable/ic_rotate_right_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M15.55,5.55L11,1v3.07C7.06,4.56 4,7.92 4,12s3.05,7.44 7,7.93v-2.02c-2.84,-0.48 -5,-2.94 -5,-5.91s2.16,-5.43 5,-5.91L11,10l4.55,-4.45zM19.93,11c-0.17,-1.39 -0.72,-2.73 -1.62,-3.89l-1.42,1.42c0.54,0.75 0.88,1.6 1.02,2.47h2.02zM13,17.9v2.02c1.39,-0.17 2.74,-0.71 3.9,-1.61l-1.44,-1.44c-0.75,0.54 -1.59,0.89 -2.46,1.03zM16.89,15.48l1.42,1.41c0.9,-1.16 1.45,-2.5 1.62,-3.89h-2.02c-0.14,0.87 -0.48,1.72 -1.02,2.48z"/>
+</vector>

--- a/project/src/main/res/drawable/ic_undo_white_24dp.xml
+++ b/project/src/main/res/drawable/ic_undo_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>
+</vector>

--- a/project/src/main/res/layout/status.xml
+++ b/project/src/main/res/layout/status.xml
@@ -32,6 +32,7 @@
         android:gravity="end|center_vertical"
         android:text="32"
         android:textColor="@color/black"
+        app:autoSizeMaxTextSize="80sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@id/status_opening"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -64,6 +65,7 @@
         android:gravity="start|center_vertical"
 
         android:text="32"
+        app:autoSizeMaxTextSize="80sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@id/status_opening"
         app:layout_constraintLeft_toRightOf="@id/doubledot"

--- a/project/src/main/res/layout/status.xml
+++ b/project/src/main/res/layout/status.xml
@@ -98,50 +98,50 @@
         <ImageButton
             android:id="@+id/status_first_move"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="48dp"
+            android:layout_weight="1"
             android:background="@color/board_color"
             android:contentDescription="@string/menu_item_first_move"
             android:onClick="undoAll"
             android:paddingLeft="5dp"
             android:paddingRight="5dp"
-            android:src="@android:drawable/ic_delete" />
+            android:src="@drawable/ic_fast_rewind_white_24dp" />
 
         <ImageButton
             android:id="@+id/status_undo"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="48dp"
+            android:layout_weight="1"
             android:background="@color/board_color"
             android:contentDescription="@string/menu_item_undo"
             android:onClick="undo"
             android:paddingLeft="5dp"
             android:paddingRight="5dp"
-            android:src="@android:drawable/ic_delete" />
+            android:src="@drawable/ic_undo_white_24dp" />
 
         <ImageButton
             android:id="@+id/status_redo"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="48dp"
+            android:layout_weight="1"
             android:background="@color/board_color"
             android:contentDescription="@string/menu_item_redo"
             android:onClick="redo"
             android:paddingLeft="5dp"
             android:paddingRight="5dp"
-            android:src="@android:drawable/ic_input_delete" />
+            android:src="@drawable/ic_redo_white_24dp" />
 
         <ImageButton
             android:id="@+id/status_rotate"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="48dp"
+            android:layout_weight="1"
             android:background="@color/board_color"
             android:contentDescription="@string/gameover_choices_rotate"
             android:onClick="rotate"
             android:paddingLeft="5dp"
             android:paddingRight="5dp"
-            android:src="@android:drawable/ic_delete" />
+            android:src="@drawable/ic_rotate_right_white_24dp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/project/src/main/res/layout/status.xml
+++ b/project/src/main/res/layout/status.xml
@@ -30,6 +30,7 @@
 
 
         android:gravity="end|center_vertical"
+        android:maxLines="1"
         android:text="32"
         android:textColor="@color/black"
         app:autoSizeMaxTextSize="80sp"
@@ -64,6 +65,7 @@
         android:layout_height="0dp"
         android:gravity="start|center_vertical"
 
+        android:maxLines="1"
         android:text="32"
         app:autoSizeMaxTextSize="80sp"
         app:autoSizeTextType="uniform"

--- a/project/src/main/res/layout/status.xml
+++ b/project/src/main/res/layout/status.xml
@@ -1,147 +1,162 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_status"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/board_color"
-    android:orientation="vertical">
+    android:padding="8dp">
 
-    <LinearLayout
-        android:layout_width="wrap_content"
+
+    <TextView
+        android:id="@+id/status_settings"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:gravity="center_horizontal"
-        android:orientation="horizontal"
-        android:paddingTop="5dp">
 
-        <TextView
-            android:id="@+id/blackscore"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:width="120dp"
-            android:gravity="end"
-            android:text="32"
-            android:textColor="@color/black"
-            android:textSize="30sp"
-            tools:ignore="HardcodedText" />
+        android:gravity="center"
+        android:text="Mid: 20 Exakt: 22 G/V: 0"
 
-        <TextView
-            android:id="@+id/doubledot"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:paddingLeft="10dp"
-            android:paddingRight="10dp"
-            android:text=":"
-            android:textSize="30sp"
-            tools:ignore="HardcodedText" />
+        app:layout_constraintBottom_toTopOf="@id/doubledot"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="HardcodedText" />
 
-        <TextView
-            android:id="@+id/whitescore"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:width="120dp"
-            android:gravity="start"
-            android:text="32"
-            android:textSize="30sp"
-            tools:ignore="HardcodedText" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/blackscore"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_gravity="bottom"
-        android:layout_weight="2"
-        android:gravity="bottom|end"
-        android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/status_opening"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="3"
-            android:gravity="start"
-            android:paddingStart="15dp"
-            android:paddingLeft="15dp"
-            android:paddingRight="15dp"
-            android:textSize="12sp"
-            android:text="Opening"
-            tools:ignore="HardcodedText" />
 
-        <TextView
-            android:id="@+id/status_settings"
-            android:layout_width="0dp"
-            android:layout_height="60dp"
-            android:layout_weight="1"
-            android:gravity="end"
-            android:paddingStart="15dp"
-            android:paddingLeft="15dp"
-            android:paddingRight="15dp"
-            android:textSize="12sp"
-            android:text="Mid: 20 Exakt: 22 G/V: 0"
-            tools:ignore="HardcodedText" />
+        android:gravity="end|center_vertical"
+        android:text="32"
+        android:textColor="@color/black"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@id/status_opening"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/doubledot"
+        app:layout_constraintTop_toBottomOf="@id/status_settings"
+        tools:ignore="HardcodedText" />
 
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/doubledot"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_gravity="bottom|center_horizontal"
-        android:layout_weight="1"
-        android:gravity="bottom|center_horizontal"
-        android:orientation="horizontal"
-        android:paddingBottom="5dp">
+        android:gravity="center"
+        android:text=":"
 
-        <ImageButton
-            android:id="@+id/status_first_move"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_weight="1"
-            android:background="@color/board_color"
-            android:contentDescription="@string/menu_item_first_move"
-            android:onClick="undoAll"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
-            android:src="@drawable/ic_fast_rewind_white_24dp" />
 
-        <ImageButton
-            android:id="@+id/status_undo"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_weight="1"
-            android:background="@color/board_color"
-            android:contentDescription="@string/menu_item_undo"
-            android:onClick="undo"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
-            android:src="@drawable/ic_undo_white_24dp" />
+        android:textColor="#58FFFF"
+        android:visibility="visible"
+        app:autoSizeMaxTextSize="48sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@id/status_opening"
+        app:layout_constraintLeft_toRightOf="@id/blackscore"
+        app:layout_constraintRight_toLeftOf="@id/whitescore"
+        app:layout_constraintTop_toBottomOf="@id/status_settings"
+        tools:ignore="HardcodedText" />
 
-        <ImageButton
-            android:id="@+id/status_redo"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_weight="1"
-            android:background="@color/board_color"
-            android:contentDescription="@string/menu_item_redo"
-            android:onClick="redo"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
-            android:src="@drawable/ic_redo_white_24dp" />
+    <TextView
+        android:id="@+id/whitescore"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="start|center_vertical"
 
-        <ImageButton
-            android:id="@+id/status_rotate"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_weight="1"
-            android:background="@color/board_color"
-            android:contentDescription="@string/gameover_choices_rotate"
-            android:onClick="rotate"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
-            android:src="@drawable/ic_rotate_right_white_24dp" />
-    </LinearLayout>
+        android:text="32"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@id/status_opening"
+        app:layout_constraintLeft_toRightOf="@id/doubledot"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/status_settings"
+        tools:ignore="HardcodedText" />
 
-</LinearLayout>
+
+    <TextView
+        android:id="@+id/status_opening"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:gravity="center"
+        android:text="Opening"
+
+        app:layout_constraintBottom_toTopOf="@id/status_undo"
+
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/doubledot"
+        tools:ignore="HardcodedText" />
+
+
+    <ImageButton
+        android:id="@+id/status_first_move"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+
+
+
+        android:background="@color/board_color"
+
+        android:contentDescription="@string/menu_item_first_move"
+        android:onClick="undoAll"
+        android:src="@drawable/ic_fast_rewind_white_24dp"
+        app:layout_constraintBottom_toBottomOf="@id/group_navigation"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+
+        app:layout_constraintLeft_toLeftOf="@id/group_navigation"
+        app:layout_constraintRight_toLeftOf="@id/status_undo"
+       />
+
+    <ImageButton
+        android:id="@+id/status_undo"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/board_color"
+        android:contentDescription="@string/menu_item_undo"
+        android:onClick="undo"
+
+        android:src="@drawable/ic_undo_white_24dp"
+
+        app:layout_constraintBottom_toBottomOf="@id/group_navigation"
+        app:layout_constraintLeft_toRightOf="@id/status_first_move"
+        app:layout_constraintRight_toLeftOf="@id/status_redo" />
+
+
+    <ImageButton
+        android:id="@+id/status_redo"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/board_color"
+        android:contentDescription="@string/menu_item_redo"
+        android:onClick="redo"
+
+        android:src="@drawable/ic_redo_white_24dp"
+        app:layout_constraintBottom_toBottomOf="@id/group_navigation"
+        app:layout_constraintLeft_toRightOf="@id/status_undo"
+        app:layout_constraintRight_toLeftOf="@id/status_rotate" />
+
+    <ImageButton
+        android:id="@+id/status_rotate"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/board_color"
+
+        android:contentDescription="@string/gameover_choices_rotate"
+
+        android:onClick="rotate"
+        android:src="@drawable/ic_rotate_right_white_24dp"
+        app:layout_constraintBottom_toBottomOf="@id/group_navigation"
+        app:layout_constraintLeft_toRightOf="@id/status_redo"
+        app:layout_constraintRight_toRightOf="parent" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/group_navigation"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        app:constraint_referenced_ids="status_first_move,status_undo,status_redo,status_rotate"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+ />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* Add resources for the bottom of screen icons so that they are visible in the Android Studio layout designer and need not be set at runtime.

* Convert status.xml to use Constraint Layouts
https://developer.android.com/training/constraint-layout
This should allow the area to be "responsive" and adjust itself based on the space available

* The "Engine status" and "Opening" lines are now on separate horizontal lines.

* Change the colon color to blue, so it doesn't look like it is owned bywhite. (Do we even need the colon to be there?)


Screenshots:

Note: The "settings" and "opening" font and bottom row icon size should be the same on both these devices, even though it looks different due to the image scaling here on Github

720x1280 - Android 7.1.1
![Screenshot_1563479296](https://user-images.githubusercontent.com/5096681/61487487-4e031180-a9a6-11e9-9f1a-99e3b1d94e92.png)

1600x2560 - Android 9.+
![Screenshot_1563479377](https://user-images.githubusercontent.com/5096681/61487494-53605c00-a9a6-11e9-91d3-bc59e0fa4043.png)
